### PR TITLE
feat: improve debug log level and add fail-if-detect-fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2023-09-12
+
+### Changed
+
+- Re-add `fail-on-all-policy-severities` input
+- Change log level on debug to another key
+- Auto-enable diagnostic mode when debug mode is enabled
+- Add `fail-if-detect-fails` input to propagate detect error as action failure
+
 ## [1.1.0] - 2023-09-11
 
 ### Added
@@ -36,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve logging
 - Update dependencies and refactor action
 
-[Unreleased]: https://github.com/mercedesbenzio/detect-action/compare/v1.1.0...main
+[Unreleased]: https://github.com/mercedesbenzio/detect-action/compare/v1.2.0...main
+[1.2.0]: https://github.com/mercedesbenzio/detect-action/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mercedesbenzio/detect-action/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mercedesbenzio/detect-action/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/mercedesbenzio/detect-action/releases/tag/v0.4.0

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
       even if the certificate is not in the keystore.
     required: false
     default: 'true'
+  fail-if-detect-fails:
+    description: 'Fail the action if detect exits with an error code'
+    required: false
+    default: 'false'
 outputs:
   detect-exit-code:
     description: 'A number indicating Detect exit code'

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,12 @@ inputs:
         - INTELLIGENT: persists the results and allows all features of Detect.
     required: false
     default: 'RAPID'
+  fail-on-all-policy-severities:
+    description: |-
+      By default, Detect will only fail on policy violations with BLOCKER or CRITICAL severities.
+      This flag will cause the action to fail on all policy severities.
+    required: false
+    default: 'false'
   output-path-override:
     description: 'Override for where to output Detect files, default is $RUNNER_TEMP/blackduck/'
     required: false
@@ -35,8 +41,8 @@ inputs:
     description: |-
       When set to true Detect will trust the Black Duck certificate
       even if the certificate is not in the keystore.
-    default: 'true'
     required: false
+    default: 'true'
 outputs:
   detect-exit-code:
     description: 'A number indicating Detect exit code'

--- a/dist/index.js
+++ b/dist/index.js
@@ -25535,7 +25535,7 @@ class DetectFacade {
             `--detect.scan.output.path=${outputPath}`
         ];
         if (core.isDebug()) {
-            detectArguments.push('--logging.level.detect=DEBUG');
+            detectArguments.push('--logging.level.detect=DEBUG', '--logging.level.com.synopsys.integration=DEBUG');
         }
         return detectArguments;
     }

--- a/src/detect/detect-facade.ts
+++ b/src/detect/detect-facade.ts
@@ -102,7 +102,10 @@ export class DetectFacade {
       `--detect.scan.output.path=${outputPath}`
     ]
     if (core.isDebug()) {
-      detectArguments.push('--logging.level.detect=DEBUG')
+      detectArguments.push(
+        '--logging.level.detect=DEBUG',
+        '--logging.level.com.synopsys.integration=DEBUG'
+      )
     }
     return detectArguments
   }

--- a/src/detect/detect-facade.ts
+++ b/src/detect/detect-facade.ts
@@ -139,7 +139,7 @@ export class DetectFacade {
   }
 
   private async processRapidScanResult(
-    exitedWithFailurePolicyViolation: boolean,
+    failureConditionsMet: boolean,
     outputPath: string
   ): Promise<boolean> {
     core.info(
@@ -152,7 +152,7 @@ export class DetectFacade {
     const reportResult = await this.blackDuckReportGenerator.generateReport(
       scanJsonPaths[0],
       {
-        failureConditionsMet: exitedWithFailurePolicyViolation,
+        failureConditionsMet,
         maxSize: MAX_REPORT_SIZE
       }
     )
@@ -175,7 +175,7 @@ export class DetectFacade {
 
   private async processDetectResult(
     outputPath: string,
-    exitedWithFailurePolicyViolation: boolean
+    failureConditionsMet: boolean
   ): Promise<boolean> {
     core.info(`${TOOL_NAME} executed successfully.`)
 
@@ -183,7 +183,7 @@ export class DetectFacade {
 
     if (this.inputs.scanMode === RAPID_SCAN) {
       hasPolicyViolations = await this.processRapidScanResult(
-        exitedWithFailurePolicyViolation,
+        failureConditionsMet,
         outputPath
       )
     }
@@ -257,7 +257,8 @@ export class DetectFacade {
     if (isSuccessOrPolicyFailure) {
       const hasPolicyViolations = await this.processDetectResult(
         outputPath,
-        detectExitCode === ExitCode.FAILURE_POLICY_VIOLATION
+        detectExitCode === ExitCode.FAILURE_POLICY_VIOLATION ||
+          this.inputs.failOnAllPolicySeverities
       )
 
       if (hasPolicyViolations) {

--- a/src/input/inputs.ts
+++ b/src/input/inputs.ts
@@ -9,6 +9,7 @@ export interface Inputs {
   failOnAllPolicySeverities: boolean
   outputPathOverride: string
   detectTrustCertificate: string
+  failIfDetectFails: boolean
 }
 
 export enum Input {
@@ -20,7 +21,8 @@ export enum Input {
   SCAN_MODE = 'scan-mode',
   FAIL_ON_ALL_POLICY_SEVERITIES = 'fail-on-all-policy-severities',
   OUTPUT_PATH_OVERRIDE = 'output-path-override',
-  DETECT_TRUST_CERTIFICATE = 'detect-trust-cert'
+  DETECT_TRUST_CERTIFICATE = 'detect-trust-cert',
+  FAIL_IF_DETECT_FAILS = 'fail-if-detect-fails'
 }
 
 export function gatherInputs(): Inputs {
@@ -32,6 +34,7 @@ export function gatherInputs(): Inputs {
   const failOnAllPolicySeverities = getInputFailOnAllPolicySeverities()
   const outputPathOverride = getInputOutputPathOverride()
   const detectTrustCertificate = getInputDetectTrustCertificate()
+  const failIfDetectFails = getInputFailIfDetectFails()
   return {
     token,
     blackDuckUrl,
@@ -40,7 +43,8 @@ export function gatherInputs(): Inputs {
     scanMode,
     failOnAllPolicySeverities,
     outputPathOverride,
-    detectTrustCertificate
+    detectTrustCertificate,
+    failIfDetectFails
   }
 }
 
@@ -74,4 +78,8 @@ function getInputOutputPathOverride(): string {
 
 function getInputDetectTrustCertificate(): string {
   return core.getInput(Input.DETECT_TRUST_CERTIFICATE)
+}
+
+function getInputFailIfDetectFails(): boolean {
+  return core.getBooleanInput(Input.FAIL_IF_DETECT_FAILS)
 }

--- a/src/input/inputs.ts
+++ b/src/input/inputs.ts
@@ -6,6 +6,7 @@ export interface Inputs {
   blackDuckApiToken: string
   detectVersion?: string
   scanMode: string
+  failOnAllPolicySeverities: boolean
   outputPathOverride: string
   detectTrustCertificate: string
 }
@@ -17,6 +18,7 @@ export enum Input {
   BLACKDUCK_API_TOKEN = 'blackduck-api-token',
   DETECT_VERSION = 'detect-version',
   SCAN_MODE = 'scan-mode',
+  FAIL_ON_ALL_POLICY_SEVERITIES = 'fail-on-all-policy-severities',
   OUTPUT_PATH_OVERRIDE = 'output-path-override',
   DETECT_TRUST_CERTIFICATE = 'detect-trust-cert'
 }
@@ -27,6 +29,7 @@ export function gatherInputs(): Inputs {
   const blackDuckApiToken = getInputBlackDuckApiToken()
   const detectVersion = getInputDetectVersion()
   const scanMode = getInputScanMode()
+  const failOnAllPolicySeverities = getInputFailOnAllPolicySeverities()
   const outputPathOverride = getInputOutputPathOverride()
   const detectTrustCertificate = getInputDetectTrustCertificate()
   return {
@@ -35,6 +38,7 @@ export function gatherInputs(): Inputs {
     blackDuckApiToken,
     detectVersion,
     scanMode,
+    failOnAllPolicySeverities,
     outputPathOverride,
     detectTrustCertificate
   }
@@ -58,6 +62,10 @@ function getInputDetectVersion(): string | undefined {
 
 function getInputScanMode(): string {
   return core.getInput(Input.SCAN_MODE).toUpperCase()
+}
+
+function getInputFailOnAllPolicySeverities(): boolean {
+  return core.getBooleanInput(Input.FAIL_ON_ALL_POLICY_SEVERITIES)
 }
 
 function getInputOutputPathOverride(): string {


### PR DESCRIPTION
This PR addresses the following:
- Re-add `fail-on-all-policy-severities` input
- Change log level on debug to another key
- Auto-enable diagnostic mode when debug mode is enabled
- Add `fail-if-detect-fails` input to propagate detect error as action failure