### PR TITLE
feat: add input to control PR comments on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2023-09-19
+
+### Added
+
+- Add `comment-pr-on-success` input to control PR comments on success
+
 ## [1.2.0] - 2023-09-12
 
 ### Changed
@@ -45,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve logging
 - Update dependencies and refactor action
 
-[Unreleased]: https://github.com/mercedesbenzio/detect-action/compare/v1.2.0...main
+[Unreleased]: https://github.com/mercedesbenzio/detect-action/compare/v1.3.0...main
+[1.3.0]: https://github.com/mercedesbenzio/detect-action/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mercedesbenzio/detect-action/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mercedesbenzio/detect-action/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mercedesbenzio/detect-action/compare/v0.4.0...v1.0.0

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: 'Fail the action if detect exits with an error code'
     required: false
     default: 'false'
+  comment-pr-on-success:
+    description: 'Comment pull requests if no violations found'
+    required: false
+    default: 'true'
 outputs:
   detect-exit-code:
     description: 'A number indicating Detect exit code'

--- a/dist/index.js
+++ b/dist/index.js
@@ -25571,8 +25571,10 @@ class DetectFacade {
             failureConditionsMet,
             maxSize: MAX_REPORT_SIZE
         });
-        if (this.context.isPullRequest()) {
-            core.info('This is a pull request, commenting...');
+        const commentInContext = (this.inputs.commentPrOnSuccess && !reportResult.failed) ||
+            reportResult.failed;
+        if (this.context.isPullRequest() && commentInContext) {
+            core.info('Commenting pull request...');
             await this.commentReporter.report(reportResult);
             core.info('Successfully commented on PR.');
         }
@@ -26228,6 +26230,7 @@ var Input;
     Input["OUTPUT_PATH_OVERRIDE"] = "output-path-override";
     Input["DETECT_TRUST_CERTIFICATE"] = "detect-trust-cert";
     Input["FAIL_IF_DETECT_FAILS"] = "fail-if-detect-fails";
+    Input["COMMENT_PR_ON_SUCCESS"] = "comment-pr-on-success";
 })(Input || (exports.Input = Input = {}));
 function gatherInputs() {
     const token = getInputGitHubToken();
@@ -26239,6 +26242,7 @@ function gatherInputs() {
     const outputPathOverride = getInputOutputPathOverride();
     const detectTrustCertificate = getInputDetectTrustCertificate();
     const failIfDetectFails = getInputFailIfDetectFails();
+    const commentPrOnSuccess = getInputCommentPrOnSuccess();
     return {
         token,
         blackDuckUrl,
@@ -26248,7 +26252,8 @@ function gatherInputs() {
         failOnAllPolicySeverities,
         outputPathOverride,
         detectTrustCertificate,
-        failIfDetectFails
+        failIfDetectFails,
+        commentPrOnSuccess
     };
 }
 exports.gatherInputs = gatherInputs;
@@ -26278,6 +26283,9 @@ function getInputDetectTrustCertificate() {
 }
 function getInputFailIfDetectFails() {
     return core.getBooleanInput(Input.FAIL_IF_DETECT_FAILS);
+}
+function getInputCommentPrOnSuccess() {
+    return core.getBooleanInput(Input.COMMENT_PR_ON_SUCCESS);
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "detect-action",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "detect-action",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@actions/artifact": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detect-action",
   "description": "Richly integrate Synopsys Detect and Black Duck policy into your GitHub Action pipelines",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Mercedes-Benz.io",
   "private": true,
   "homepage": "https://github.com/mercedesbenzio/detect-action",

--- a/src/detect/detect-facade.ts
+++ b/src/detect/detect-facade.ts
@@ -160,8 +160,12 @@ export class DetectFacade {
       }
     )
 
-    if (this.context.isPullRequest()) {
-      core.info('This is a pull request, commenting...')
+    const commentInContext =
+      (this.inputs.commentPrOnSuccess && !reportResult.failed) ||
+      reportResult.failed
+
+    if (this.context.isPullRequest() && commentInContext) {
+      core.info('Commenting pull request...')
       await this.commentReporter.report(reportResult)
       core.info('Successfully commented on PR.')
     }

--- a/src/input/inputs.ts
+++ b/src/input/inputs.ts
@@ -10,6 +10,7 @@ export interface Inputs {
   outputPathOverride: string
   detectTrustCertificate: string
   failIfDetectFails: boolean
+  commentPrOnSuccess: boolean
 }
 
 export enum Input {
@@ -22,7 +23,8 @@ export enum Input {
   FAIL_ON_ALL_POLICY_SEVERITIES = 'fail-on-all-policy-severities',
   OUTPUT_PATH_OVERRIDE = 'output-path-override',
   DETECT_TRUST_CERTIFICATE = 'detect-trust-cert',
-  FAIL_IF_DETECT_FAILS = 'fail-if-detect-fails'
+  FAIL_IF_DETECT_FAILS = 'fail-if-detect-fails',
+  COMMENT_PR_ON_SUCCESS = 'comment-pr-on-success'
 }
 
 export function gatherInputs(): Inputs {
@@ -35,6 +37,7 @@ export function gatherInputs(): Inputs {
   const outputPathOverride = getInputOutputPathOverride()
   const detectTrustCertificate = getInputDetectTrustCertificate()
   const failIfDetectFails = getInputFailIfDetectFails()
+  const commentPrOnSuccess = getInputCommentPrOnSuccess()
   return {
     token,
     blackDuckUrl,
@@ -44,7 +47,8 @@ export function gatherInputs(): Inputs {
     failOnAllPolicySeverities,
     outputPathOverride,
     detectTrustCertificate,
-    failIfDetectFails
+    failIfDetectFails,
+    commentPrOnSuccess
   }
 }
 
@@ -82,4 +86,8 @@ function getInputDetectTrustCertificate(): string {
 
 function getInputFailIfDetectFails(): boolean {
   return core.getBooleanInput(Input.FAIL_IF_DETECT_FAILS)
+}
+
+function getInputCommentPrOnSuccess(): boolean {
+  return core.getBooleanInput(Input.COMMENT_PR_ON_SUCCESS)
 }


### PR DESCRIPTION
This PR addresses the following:

- Add `comment-pr-on-success` input to control PR comments on success