### PR TITLE
feat: decrease PR comment font size

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26317,8 +26317,12 @@ exports.BlackDuckReportGenerator = void 0;
 const text_builder_1 = __nccwpck_require__(8758);
 const HEADER = '| Policies Violated | Dependency | License(s) | Vulnerabilities | Short Term Recommended Upgrade | Long Term Recommended Upgrade |';
 const HEADER_ALIGNMENT = '|-|-|-|-|-|-|';
-const SUCCESS_COMMENT = '# :white_check_mark: Black Duck - None of your dependencies violate policy!';
-const FAIL_COMMENT = (fail) => `# ${fail ? ':x:' : ':warning:'} Black Duck - Found dependencies violating policy!`;
+const SUCCESS_COMMENT = `### :white_check_mark: Black Duck
+
+None of your dependencies violate policy!`;
+const FAIL_COMMENT = (fail) => `### ${fail ? ':x:' : ':warning:'} Black Duck
+
+  Found dependencies violating policy!`;
 class BlackDuckReportGenerator {
     blackDuckScanReportGenerator;
     constructor(blackDuckScanReportGenerator) {

--- a/src/report/blackduck-report-generator.ts
+++ b/src/report/blackduck-report-generator.ts
@@ -15,12 +15,13 @@ const HEADER =
   '| Policies Violated | Dependency | License(s) | Vulnerabilities | Short Term Recommended Upgrade | Long Term Recommended Upgrade |'
 const HEADER_ALIGNMENT = '|-|-|-|-|-|-|'
 
-const SUCCESS_COMMENT =
-  '# :white_check_mark: Black Duck - None of your dependencies violate policy!'
+const SUCCESS_COMMENT = `### :white_check_mark: Black Duck
+
+None of your dependencies violate policy!`
 const FAIL_COMMENT = (fail: boolean): string =>
-  `# ${
-    fail ? ':x:' : ':warning:'
-  } Black Duck - Found dependencies violating policy!`
+  `### ${fail ? ':x:' : ':warning:'} Black Duck
+
+  Found dependencies violating policy!`
 
 export class BlackDuckReportGenerator
   implements ReportGenerator<ReportProperties, ReportResult>


### PR DESCRIPTION
This Pull Request is intended to provide a different message structure for each comment made on Pull Requests.

#### Previously:

<img width="921" alt="Screenshot 2024-03-07 at 10 48 36" src="https://github.com/tvcsantos/detect-action/assets/5599803/0ab8970e-9c32-4bb8-be3f-e1b173bfc034">

The problem I see is the size of the message, it differs from other messages I might have on the same Pull Request

#### Suggestion:

<img width="923" alt="Screenshot 2024-03-07 at 10 58 46" src="https://github.com/tvcsantos/detect-action/assets/5599803/173eed46-fc8d-4da8-bd63-dd48f95a53e1">

<img width="857" alt="Screenshot 2024-03-07 at 11 17 00" src="https://github.com/tvcsantos/detect-action/assets/5599803/c57b058e-cc1f-4889-a192-6e393f15a822">

Message has less impact on the way it is transmitted, the secondary message is displayed below with no bold style.

Second image is just an example of the header and secondary message, there is no intention to remove the table
