### PR TITLE
fix: relocate where diagnostics are uploaded

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43482,11 +43482,10 @@ async function run() {
 // eslint-disable-next-line github/no-then
 run().catch(error => {
     core.error(error);
-    if (error instanceof Error) {
-        if (error.stack)
-            core.error(error.stack);
-        core.setFailed(error.message);
-    }
+    // TypeError is not a decendant class of Error (instanceof)
+    if (error.stack)
+        core.error(error.stack);
+    core.setFailed(error.message);
 });
 
 

--- a/src/detect/detect-facade.ts
+++ b/src/detect/detect-facade.ts
@@ -191,11 +191,6 @@ export class DetectFacade {
       )
     }
 
-    if (this.isDiagnosticModeEnabled()) {
-      const diagnosticZip = await this.getDiagnosticFilesPaths(outputPath)
-      await uploadArtifact('Detect Diagnostic Zip', outputPath, diagnosticZip)
-    }
-
     return hasPolicyViolations
   }
 
@@ -253,6 +248,12 @@ export class DetectFacade {
     core.info(
       `${TOOL_NAME} exited with code ${detectExitCode} - ${exitCodeName}.`
     )
+
+    // always process diagnostics regardless of exit code
+    if (this.isDiagnosticModeEnabled()) {
+      const diagnosticZip = await this.getDiagnosticFilesPaths(outputPath)
+      await uploadArtifact('Detect Diagnostic Zip', outputPath, diagnosticZip)
+    }
 
     const isSuccessOrPolicyFailure =
       detectExitCode === ExitCode.SUCCESS ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ async function run(): Promise<void> {
 // eslint-disable-next-line github/no-then
 run().catch(error => {
   core.error(error)
-  if (error instanceof Error) {
-    if (error.stack) core.error(error.stack)
-    core.setFailed(error.message)
-  }
+
+  // TypeError is not a decendant class of Error (instanceof)
+  if (error.stack) core.error(error.stack)
+  core.setFailed(error.message)
 })


### PR DESCRIPTION
Diagnostics would only get uploaded with exit code 0 or 3. This resolves it.
Also TypeError is not a decendant class of Error so you'll never get a stack trace.